### PR TITLE
Subscription Driven Datadog OOTB Module

### DIFF
--- a/docker_monitors.tf
+++ b/docker_monitors.tf
@@ -1,0 +1,3 @@
+# resource "datadog_monitor" "docker" {
+#   count = var.docker_monitors_enabled == "true" ? 1 : 0
+# }

--- a/host_monitors.tf
+++ b/host_monitors.tf
@@ -1,0 +1,25 @@
+data "template_file" "system_disk_used" {
+  template = file(
+    "${path.module}/runbook_templates/system_disk_used.tpl",
+  )
+
+  vars = {
+    notification_receivers = var.system_disk_used_notification_receivers
+  }
+}
+
+resource "datadog_monitor" "system_disk_used" {
+  type  = "metric alert"
+  name  = "[System][{host.name}] Disk space is running low."
+  query = "min(last_5m):avg:system.disk.in_use{${var.system_disk_used_scope_string}} by {host,device} * 100 > ${var.system_disk_used_alert_threshold}"
+  # More standarised Runbooks
+  message = data.template_file.system_disk_used.rendered
+
+  notify_no_data    = var.system_disk_used_notify_no_data
+  no_data_timeframe = var.system_disk_used_no_data_timeframe
+  include_tags      = true
+  tags              = ["standard:true", "terraform:true"]
+
+  # OOTB Resources for "host"
+  count = var.host_monitors_enabled == "true" ? 1 : 0
+}

--- a/runbook_templates/system_disk_used.tpl
+++ b/runbook_templates/system_disk_used.tpl
@@ -1,0 +1,9 @@
+Alert | User CPU is high
+
+Instructions:
+
+1. Check system metrics on [this dashboard](https://app.datadoghq.com/dash/integration/1?tpl_var_scope=host%3A{{host.name}})
+2. If <CONDITION>, read [internal documentation]() for further instructions
+3. If <CONDITION>, read [internal documentation]() for further instructions
+
+${notification_receivers}

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,10 @@
+module "datadog_ootb" {
+  # source = "https://github.com/nxnarbais/terraform-datadog.git"
+  source = "../../terraform-datadog"
+
+  # configurable option to swtich off a seriers of host resources
+  host_monitors_enabled = "true"
+  # customisable configurations
+  system_disk_used_scope_string           = "env:shop.ist,!env:test"
+  system_disk_used_notification_receivers = "@slack-scott-demo @daniel.lin@datadoghq.com"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "host_monitors_enabled" {
+  default     = "true"
+  description = "Provision default hosts monitors."
+}
+
+variable "docker_monitors_enabled" {
+  default     = "true"
+  description = "Provision default docker monitors."
+}
+
+variable "system_disk_used_scope_string" {
+  default     = ""
+  description = "Comma seperated string to scope and exclude tags, e.g. account:demo3,!env:test,!env:datad0g.com"
+}
+
+variable "system_disk_used_alert_threshold" {
+  default = 80
+}
+
+variable "system_disk_used_notify_no_data" {
+  default = true
+}
+
+variable "system_disk_used_no_data_timeframe" {
+  default = 120
+}
+
+variable "system_disk_used_notification_receivers" {
+  default     = ""
+  description = "Space seperated string of receivers for this monitor notification, e.g. @slack-infra @daniel.lin@datadoghq.com"
+}


### PR DESCRIPTION
- restructure layout so this module can be imported directly from GitHub
- use `count` to determine whehter to provision ootb resources
- introduce tpl template to standarise runbooks